### PR TITLE
Bug fix for cloned recipe template

### DIFF
--- a/static/styles/main.less
+++ b/static/styles/main.less
@@ -229,10 +229,18 @@ textarea.large {
     .title {
         font-size: 16pt;
         font-family: 'Germania One', sans-serif;
+        line-height: 120%;
+        margin-top: -5px;
+        margin-bottom: -2px;
 
         a {
             text-decoration: none;
         }
+    }
+
+    .missing {
+        display: inline-block;
+        margin: .25em 0 0 0;
     }
 
     .stats {

--- a/templates/recipe-embed-404.html
+++ b/templates/recipe-embed-404.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" type="text/css" href="/static/styles/bootstrap.min.css"/>
+        <link rel="stylesheet" type="text/css" href="/static/styles/main.css?v=1348551740"/>
+        <script type="text/javascript">
+            var _gaq = _gaq || [];
+            _gaq.push(['_setAccount', 'UA-16567764-4']);
+            _gaq.push(['_trackPageview']);
+
+            (function() {
+                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+            })();
+        </script>
+    </head>
+    <body class="embed">
+        <div class="recipe" style="width: {{ width - 26 }}px;">
+            <span class="title ellipsize">Oops, missing recipe!</span>
+            <br/>
+            <span class="missing">It appears this recipe was deleted by its {% if publicuser %}<a href="/users/{{ publicuser.name }}" target="_top">owner</a>{% else %}owner{% endif %}. Feel free to check out other recipes on <a href="/" target="_top">Malt<span style="opacity: 0.6">.io</span></a>!</span>
+            <br/>
+            <div class="footer">
+                Powered by <a href="/" target="_top">Malt<span style="opacity: 0.6">.io</span></a>
+            </div>
+        </div>
+        <script type="text/javascript" src="http://code.jquery.com/jquery-1.7.2.min.js"></script>
+        <script type="text/javascript" src="/static/scripts/bootstrap.min.js"></script>
+        <script type="text/javascript" src="/static/scripts/main.js?v=1348551740"></script>
+    </body>
+</html>

--- a/templates/recipe.html
+++ b/templates/recipe.html
@@ -81,7 +81,7 @@
     <div class="hero-unit editable">
         {% if cloned_from %}
             <p style="opacity: 0.5;">
-                Cloned from <a href="/users/{{ recipe.cloned_from.owner.name }}">{{ cloned_from.owner.name }}</a> / <a href="/users/{{ cloned_from.owner.name }}/recipes/{{ cloned_from.slug }}">{{ recipe.name }}</a>
+                Cloned from <a href="/users/{{ cloned_from.owner.name }}">{{ cloned_from.owner.name }}</a> / <a href="/users/{{ cloned_from.owner.name }}/recipes/{{ cloned_from.slug }}">{{ cloned_from.name }}</a>
             </p>
         {% endif %}
         <div class="price-container">


### PR DESCRIPTION
Here's a tiny fix to show the source recipe name in the "Cloned from" text in the template. The original version showed the current recipe's name instead of the source recipe name.
